### PR TITLE
feat(navigation): add saved albums navigation tab (#18)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -10,6 +10,7 @@ pub enum ApiEndpoint {
     UserSongList,
     UserCreatedSongList,
     UserSubscribedSongList,
+    SavedAlbums,
     Download,
     LocalMusic,
     Recent,
@@ -29,6 +30,7 @@ impl ApiEndpoint {
         ApiEndpoint::UserSongList,
         ApiEndpoint::UserCreatedSongList,
         ApiEndpoint::UserSubscribedSongList,
+        ApiEndpoint::SavedAlbums,
         ApiEndpoint::Download,
         ApiEndpoint::LocalMusic,
         ApiEndpoint::Recent,
@@ -48,6 +50,7 @@ impl ApiEndpoint {
             ApiEndpoint::UserSongList => "user_song_list",
             ApiEndpoint::UserCreatedSongList => "user_created_song_list",
             ApiEndpoint::UserSubscribedSongList => "user_subscribed_song_list",
+            ApiEndpoint::SavedAlbums => "album_sublist",
             ApiEndpoint::Download => "__download__",
             ApiEndpoint::LocalMusic => "__local_music__",
             ApiEndpoint::Recent => "__recent__",
@@ -68,6 +71,7 @@ impl ApiEndpoint {
             "user_song_list" => Some(ApiEndpoint::UserSongList),
             "user_created_song_list" => Some(ApiEndpoint::UserCreatedSongList),
             "user_subscribed_song_list" => Some(ApiEndpoint::UserSubscribedSongList),
+            "album_sublist" => Some(ApiEndpoint::SavedAlbums),
             "__download__" => Some(ApiEndpoint::Download),
             "__local_music__" => Some(ApiEndpoint::LocalMusic),
             "__recent__" => Some(ApiEndpoint::Recent),
@@ -84,6 +88,7 @@ impl ApiEndpoint {
                 | ApiEndpoint::UserSongList
                 | ApiEndpoint::UserCreatedSongList
                 | ApiEndpoint::UserSubscribedSongList
+                | ApiEndpoint::SavedAlbums
         )
     }
 }

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -66,11 +66,10 @@ impl App {
     }
 
     pub(super) fn handle_playlist_select(&mut self, id: u64, name: Option<String>) {
-        self.playback.set_playlist_id(id);
         self.state.navigation.push_breadcrumb();
         self.state.navigation.set_content(ContentState::Loading);
 
-        let is_radio = self
+        let selected_api = self
             .state
             .navigation
             .nav
@@ -82,13 +81,23 @@ impl App {
                     .items
                     .get(i)
             })
-            .and_then(|item| item.api.as_deref())
-            == Some("user_radio_sublist");
+            .and_then(|item| item.api.as_deref());
+
+        let is_album = selected_api == Some("album_sublist");
+        let is_radio = selected_api == Some("user_radio_sublist");
+
+        if !is_album {
+            self.playback.set_playlist_id(id);
+        }
 
         let service = self.service.clone();
         let sender = self.state.events.sender();
         tokio::spawn(async move {
-            let (state, detail_name) = service.load_playlist_detail(id, is_radio).await;
+            let (state, detail_name) = if is_album {
+                (service.load_album(id).await, None)
+            } else {
+                service.load_playlist_detail(id, is_radio).await
+            };
             send_event(&sender, NavigationEvent::ContentLoaded(state).into());
             let breadcrumb = detail_name.or(name);
             if let Some(name) = breadcrumb {

--- a/src/config/navigation.rs
+++ b/src/config/navigation.rs
@@ -76,6 +76,11 @@ impl Default for NavConfig {
                             title_template: None,
                         },
                         NavItemConfig {
+                            name: " 我收藏的专辑".into(),
+                            api: Some("album_sublist".into()),
+                            title_template: None,
+                        },
+                        NavItemConfig {
                             name: " 下载管理".into(),
                             api: Some("__download__".into()),
                             title_template: None,

--- a/src/service.rs
+++ b/src/service.rs
@@ -100,6 +100,10 @@ impl ApiService {
                 },
                 None => (ContentState::Error("未登录".into()), None),
             },
+            ApiEndpoint::SavedAlbums => match self.client.album_sublist(0, limit).await {
+                Ok(albums) => (ContentState::SongLists(albums), None),
+                Err(e) => (ContentState::Error(e.to_string()), None),
+            },
             ApiEndpoint::Search => match self.client.search_hot().await {
                 Ok(items) => (
                     ContentState::HotSearch(items.into_iter().map(|h| h.keyword).collect()),


### PR DESCRIPTION
## Summary

- Add a new saved albums navigation endpoint backed by `album_sublist`
- Add the saved albums entry to the default sidebar navigation
- Load saved album lists through the existing song-list content view
- Open saved album items through album detail loading instead of playlist detail loading

## Testing

- `cargo test --workspace --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`

## Notes
Existing user configs with explicit `navigation.sections` are not migrated automatically. Users with an older `~/.config/pigma/config.toml` need to update their navigation config manually or regenerate it to see the new sidebar item.