### PR TITLE
fix: 恢复终端状态并同步启动认证

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -430,7 +430,10 @@ impl App {
                 if self.state.offline {
                     self.navigate_to_local();
                 } else if self.service.client().is_logged_in() {
-                    self.navigate_to_main();
+                    // Wait for the authenticated user info before entering the
+                    // default tab. Login-gated endpoints need the UID returned by
+                    // this request, so loading the tab first can produce a false
+                    // "未登录" error during startup.
                     let service = self.service.clone();
                     let sender = self.state.events.sender();
                     tokio::spawn(async move {
@@ -442,6 +445,9 @@ impl App {
                             }
                             Err(e) => {
                                 log::error!("Failed to get login status: {e}");
+                                if sender.send(AuthEvent::Error(e.to_string()).into()).is_err() {
+                                    log::error!("Failed to send LoginError: receiver dropped");
+                                }
                             }
                         }
                     });

--- a/src/app/login.rs
+++ b/src/app/login.rs
@@ -4,7 +4,7 @@ use tokio::time::{Duration, sleep};
 
 use super::{App, send_event};
 use crate::{
-    event::{AuthEvent, PlaybackEvent},
+    event::{AuthEvent, NavigationEvent, PlaybackEvent},
     state::Page,
 };
 
@@ -32,11 +32,21 @@ impl App {
     pub(super) fn handle_login_success(&mut self, info: ncm_api::LoginInfo) {
         self.toast(format!("登录成功: {}", info.nickname));
         let uid = info.uid;
+        let was_logged_in = self.state.navigation.user.is_some();
         self.state.login.loading = false;
         self.state.navigation.user = Some(info);
         self.service.client().flush_cookies();
-        if self.state.navigation.page == Page::Login {
+        if matches!(self.state.navigation.page, Page::Login | Page::Splash) {
             self.navigate_to_main();
+        } else if !was_logged_in && self.state.navigation.page == Page::Main {
+            // A login event can arrive after startup has already entered the
+            // main page. Reload the selected tab once its UID is available.
+            if let Some(api) = self.state.navigation.nav.selected_api() {
+                send_event(
+                    &self.state.events.sender(),
+                    NavigationEvent::NavSelect(api.to_string()).into(),
+                );
+            }
         }
 
         // After login, fetch the "我喜欢的音乐" list from the cloud so the local set and the playerbar icon stay in sync.
@@ -60,6 +70,9 @@ impl App {
         self.toast(format!("登录失败: {}", e));
         self.state.login.loading = false;
         self.state.login.error = Some(e);
+        if self.state.navigation.page == Page::Splash {
+            self.navigate_to_main();
+        }
     }
 
     pub(super) fn handle_qr_created(&mut self, url: String, key: String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,31 @@
 //! subcommands, and otherwise initializes the terminal and launches the main
 //! `App` loop until quit.
 
-use std::io::stdout;
+use std::io::{Write, stdout};
 
 use clap::{Parser, error::ErrorKind};
-use crossterm::execute;
+use crossterm::{
+    cursor,
+    event::{DisableMouseCapture, EnableMouseCapture},
+    execute,
+    style::ResetColor,
+};
 use pigma::cli::{Cli, run_cli};
+
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let mut output = stdout();
+        // Disable mouse reporting even when the app unwinds from a panic. The
+        // ratatui panic hook restores raw mode and the alternate screen, but it
+        // does not know that Pigma enabled mouse capture separately.
+        let _ = execute!(output, DisableMouseCapture, ResetColor, cursor::Show);
+        ratatui::restore();
+        let _ = write!(output, "\r\n");
+        let _ = output.flush();
+    }
+}
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
@@ -36,9 +56,8 @@ async fn main() -> color_eyre::Result<()> {
 
     color_eyre::install()?;
     let terminal = ratatui::init();
-    execute!(stdout(), crossterm::event::EnableMouseCapture)?;
+    let _terminal_guard = TerminalGuard;
+    execute!(stdout(), EnableMouseCapture)?;
     let result = app.run(terminal).await;
-    execute!(stdout(), crossterm::event::DisableMouseCapture)?;
-    ratatui::restore();
     result
 }


### PR DESCRIPTION
问题1: 【我喜欢的音乐】排在首位时，进入pigma会提示“未登录”，实际已登录
问题2: 偶现TUI在移动光标时显示一连串的ANSCI字符，Ctrl+C退出后终端还是会在移动光标时显示ANSCI字符

修复场景：
- 正常退出和 panic 时关闭鼠标捕获；
- 重置终端颜色、恢复光标并清理 shell prompt；
- 等待启动登录状态确认后再加载需要 UID 的内容；
- 登录完成后重新加载当前选中的 Tab；
- 启动认证成功或失败后从 Splash 页面返回，并上报登录状态错误。