### PR TITLE
fix: 修复我喜欢的音乐取消喜欢后仍显示的问题

### DIFF
--- a/crates/ncm-api/src/client/interaction.rs
+++ b/crates/ncm-api/src/client/interaction.rs
@@ -20,6 +20,7 @@ impl NcmClient {
         ];
         let result = self.request_weapi("/api/radio/like", &params).await?;
         let value: Value = serde_json::from_str(&result)?;
+        Self::check_api_code(&value)?;
         parse_msg(&value).map_err(|e| NcmError::parse(e, &value))
     }
 

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -16,7 +16,7 @@ impl App {
 
     pub(super) fn handle_load_more(&mut self) {
         let (api, offset, limit) = match self.state.navigation.pagination.as_ref() {
-            Some(pg) if pg.has_more => (pg.api.clone(), pg.offset, pg.limit),
+            Some(pg) if pg.has_more => (pg.api.clone(), pg.next_offset(), pg.limit),
             _ => return,
         };
 
@@ -61,10 +61,13 @@ impl App {
         // Only song lists (cloud disk, songs within a playlist) support paged appends; other types replace the whole content.
         if same_api
             && let ContentState::Songs(new_songs) = &mut content
-            && let ContentState::Songs(existing) =
-                std::sync::Arc::make_mut(&mut self.state.navigation.content)
+            && matches!(
+                self.state.navigation.content.as_ref(),
+                ContentState::Songs(_)
+            )
         {
-            existing.extend(std::mem::take(new_songs));
+            std::sync::Arc::make_mut(&mut self.state.navigation.content)
+                .append_unique_songs(std::mem::take(new_songs));
             let pg_for_save = pagination.clone();
             self.state.navigation.pagination = Some(pagination);
 

--- a/src/app/event.rs
+++ b/src/app/event.rs
@@ -121,9 +121,32 @@ impl App {
                 {
                     self.playback.update_liked_status();
                 }
+                if !like {
+                    // The active list and its cache are snapshots; keep them in sync with the
+                    // optimistic liked-state update instead of showing the removed song until reload.
+                    self.service.cache().remove_content_cache("liked");
+                    let is_liked_root = self.state.navigation.nav.selected_api() == Some("liked")
+                        && self.state.navigation.history.is_empty();
+                    if is_liked_root {
+                        let playlist_id = self
+                            .state
+                            .navigation
+                            .pagination
+                            .as_ref()
+                            .and_then(|p| p.api.strip_prefix("playlist:"))
+                            .and_then(|id| id.parse::<u64>().ok());
+                        if self.state.navigation.remove_song(id)
+                            && let Some(playlist_id) = playlist_id
+                        {
+                            self.service.remove_cached_playlist_track(playlist_id, id);
+                        }
+                    }
+                }
                 let service = self.service.clone();
                 tokio::spawn(async move {
-                    let _ = service.like_song(id, like).await;
+                    if let Err(e) = service.like_song(id, like).await {
+                        log::warn!("Failed to update liked state for song {id}: {e}");
+                    }
                 });
             }
             PlaybackEvent::LikedUpdated => {

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -100,9 +100,8 @@ impl App {
 
             if ttl > 0
                 && !force
-                && api != ApiEndpoint::Search
+                && !matches!(api, ApiEndpoint::Search | ApiEndpoint::LikedSongs)
                 && let Some((cached, pg)) = cache.load_content_cache_async(&api_str, ttl).await
-                && (api != ApiEndpoint::LikedSongs || pg.is_some())
             {
                 // When restoring playlist pagination from cache, top up the trackIds, otherwise lazy pagination (LoadMore) cannot slice.
                 if let Some(pg) = &pg

--- a/src/cache/content.rs
+++ b/src/cache/content.rs
@@ -79,4 +79,12 @@ impl CacheManager {
             }
         }
     }
+
+    pub fn remove_content_cache(&self, api: &str) {
+        match fs::remove_file(self.content_path(api)) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => log::warn!("Failed to remove content cache for {api}: {e}"),
+        }
+    }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -263,22 +263,32 @@ impl ApiService {
             };
         };
 
-        let (songs, total) = match self.client.playlist_detail(id).await {
-            Ok((_detail, track_ids)) => {
-                let total = track_ids.len() as u64;
-                let page_limit = limit as u32;
-                let songs = match self.client.playlist_songs(&track_ids, 0, page_limit).await {
-                    Ok(s) => s,
-                    Err(e) => return (ContentState::Error(e.to_string()), None, Some(id)),
-                };
-                // Cache the full trackIds for later lazy pagination (LoadMore) slicing.
-                if let Ok(mut guard) = self.playlist_track_ids.lock() {
-                    guard.insert(id, track_ids);
+        // `liked_song_ids` is authoritative. Playlist detail can lag after an unlike and
+        // must not normally drive this list, otherwise removed songs remain visible.
+        let track_ids = match self.client.liked_song_ids(uid).await {
+            Ok(ids) => ids,
+            Err(liked_error) => match self.client.playlist_detail(id).await {
+                Ok((_detail, ids)) => {
+                    log::warn!(
+                        "liked_song_ids failed ({liked_error}); falling back to playlist detail"
+                    );
+                    ids
                 }
-                (songs, total)
-            }
+                Err(_) => {
+                    return (ContentState::Error(liked_error.to_string()), None, Some(id));
+                }
+            },
+        };
+        let total = track_ids.len() as u64;
+        let page_limit = limit as u32;
+        let songs = match self.client.playlist_songs(&track_ids, 0, page_limit).await {
+            Ok(songs) => songs,
             Err(e) => return (ContentState::Error(e.to_string()), None, Some(id)),
         };
+        // Cache the authoritative IDs for later lazy pagination (LoadMore) slicing.
+        if let Ok(mut guard) = self.playlist_track_ids.lock() {
+            guard.insert(id, track_ids);
+        }
 
         let limit = limit as u32;
         let pagination = PaginationInfo {
@@ -294,6 +304,15 @@ impl ApiService {
             Some(pagination),
             Some(id),
         )
+    }
+
+    /// Remove a track from a cached playlist ID list after an optimistic local mutation.
+    pub fn remove_cached_playlist_track(&self, playlist_id: u64, song_id: u64) {
+        if let Ok(mut guard) = self.playlist_track_ids.lock()
+            && let Some(track_ids) = guard.get_mut(&playlist_id)
+        {
+            track_ids.retain(|id| *id != song_id);
+        }
     }
 
     /// Ensure the playlist's `trackIds` are cached in memory (for `load_more` lazy pagination slicing).

--- a/src/state.rs
+++ b/src/state.rs
@@ -52,6 +52,12 @@ pub struct PaginationInfo {
     pub loading: bool,
 }
 
+impl PaginationInfo {
+    /// Offset of the next page after the currently loaded page.
+    pub fn next_offset(&self) -> u32 {
+        self.offset.saturating_add(self.limit)
+    }
+}
 impl Default for PaginationInfo {
     fn default() -> Self {
         Self {
@@ -62,6 +68,33 @@ impl Default for PaginationInfo {
             total: 0,
             loading: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod pagination_tests {
+    use super::PaginationInfo;
+
+    #[test]
+    fn next_offset_advances_past_current_page() {
+        let pagination = PaginationInfo {
+            offset: 60,
+            limit: 60,
+            ..PaginationInfo::default()
+        };
+
+        assert_eq!(pagination.next_offset(), 120);
+    }
+
+    #[test]
+    fn next_offset_saturates() {
+        let pagination = PaginationInfo {
+            offset: u32::MAX - 5,
+            limit: 60,
+            ..PaginationInfo::default()
+        };
+
+        assert_eq!(pagination.next_offset(), u32::MAX);
     }
 }
 

--- a/src/state/content.rs
+++ b/src/state/content.rs
@@ -37,6 +37,27 @@ impl ContentState {
         self.len() == 0
     }
 
+    /// Remove a song by ID from song content. Returns whether an item was removed.
+    pub fn remove_song(&mut self, song_id: u64) -> bool {
+        let ContentState::Songs(songs) = self else {
+            return false;
+        };
+        let previous_len = songs.len();
+        songs.retain(|song| song.id != song_id);
+        songs.len() != previous_len
+    }
+
+    /// Append only songs whose IDs are not already present. Returns the number appended.
+    pub fn append_unique_songs(&mut self, new_songs: Vec<Arc<SongInfo>>) -> usize {
+        let ContentState::Songs(songs) = self else {
+            return 0;
+        };
+        let mut ids: std::collections::HashSet<u64> = songs.iter().map(|song| song.id).collect();
+        let previous_len = songs.len();
+        songs.extend(new_songs.into_iter().filter(|song| ids.insert(song.id)));
+        songs.len() - previous_len
+    }
+
     pub fn content_type(&self) -> ContentType {
         match self {
             ContentState::Songs(_) => ContentType::Songs,
@@ -55,4 +76,65 @@ impl ContentState {
 pub enum TableMode {
     Row,
     Cell,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ncm_api::SongCopyright;
+
+    fn song(id: u64) -> Arc<SongInfo> {
+        Arc::new(SongInfo {
+            id,
+            name: format!("song-{id}"),
+            singer: String::new(),
+            artist_id: 0,
+            album: String::new(),
+            album_id: 0,
+            pic_url: String::new(),
+            duration: 0,
+            copyright: SongCopyright::Free,
+        })
+    }
+
+    #[test]
+    fn remove_song_removes_only_the_matching_id() {
+        let mut content = ContentState::Songs(vec![song(1), song(2), song(3)]);
+
+        assert!(content.remove_song(2));
+        let ContentState::Songs(songs) = content else {
+            panic!("expected song content");
+        };
+        assert_eq!(
+            songs.iter().map(|song| song.id).collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+    }
+
+    #[test]
+    fn remove_song_ignores_non_song_content_and_missing_ids() {
+        let mut empty = ContentState::Empty;
+        let mut songs = ContentState::Songs(vec![song(1)]);
+
+        assert!(!empty.remove_song(1));
+        assert!(!songs.remove_song(2));
+        assert_eq!(songs.len(), 1);
+    }
+
+    #[test]
+    fn append_unique_songs_skips_existing_and_incoming_duplicates() {
+        let mut content = ContentState::Songs(vec![song(1), song(2)]);
+
+        assert_eq!(
+            content.append_unique_songs(vec![song(2), song(3), song(3), song(4)]),
+            2
+        );
+        let ContentState::Songs(songs) = content else {
+            panic!("expected song content");
+        };
+        assert_eq!(
+            songs.iter().map(|song| song.id).collect::<Vec<_>>(),
+            vec![1, 2, 3, 4]
+        );
+    }
 }

--- a/src/state/navigation.rs
+++ b/src/state/navigation.rs
@@ -175,6 +175,23 @@ impl NavigationState {
         }
     }
 
+    /// Remove a song from the active content while keeping selection and pagination valid.
+    pub fn remove_song(&mut self, song_id: u64) -> bool {
+        if !Arc::make_mut(&mut self.content).remove_song(song_id) {
+            return false;
+        }
+
+        let len = self.content.len();
+        self.content_selected = self.content_selected.min(len.saturating_sub(1));
+        self.table_state
+            .select((len > 0).then_some(self.content_selected));
+        if let Some(pagination) = &mut self.pagination {
+            pagination.total = pagination.total.saturating_sub(1);
+        }
+        *self.title_cache.borrow_mut() = None;
+        true
+    }
+
     pub fn clear_breadcrumb(&mut self) {
         self.history.clear();
     }


### PR DESCRIPTION
本次 PR 修复当在《我喜欢的音乐》列表中取消喜欢某首歌后，即使强制刷新，该歌曲仍然出现在列表中的问题。                 
                                                            
具体调整：                                                 
                                       
 - 使用 liked_song_ids 作为“我喜欢的音乐”歌曲 ID 的权威来源，避免歌单详情与喜欢状态 API 短暂不一致时展示已取消喜欢的歌曲。                                                 
 - 取消喜欢时同步更新当前喜欢列表、分页数据和内存中的歌曲ID 缓存。                                                
 - 失效“我喜欢的音乐”内容缓存，避免强制刷新继续读取旧数据。 
 - 校验喜欢/取消喜欢接口的业务状态码，避免将接口业务失败误认为操作成功。                                           
 - 修复喜欢列表滚动分页时重复请求第一页的问题，并在合并分页结果时按歌曲 ID 去重。          