### PR TITLE
fix: 修复帮助面板滚动溢出导致向上滚动失效的问题

### DIFF
--- a/src/state/help.rs
+++ b/src/state/help.rs
@@ -3,6 +3,11 @@
 pub struct HelpState {
     pub open: bool,
     pub scroll: usize,
+    /// Scroll limit of the last rendered popup; refreshed on every draw so
+    /// `scroll_down` can clamp at the source instead of letting `scroll`
+    /// overflow past the bottom (which would force the user to scroll up
+    /// through the surplus before the view moves).
+    pub max_scroll: usize,
 }
 
 impl HelpState {
@@ -19,10 +24,47 @@ impl HelpState {
     }
 
     pub fn scroll_down(&mut self) {
-        self.scroll = self.scroll.saturating_add(1);
+        self.scroll = (self.scroll + 1).min(self.max_scroll);
     }
 
     pub fn scroll_up(&mut self) {
         self.scroll = self.scroll.saturating_sub(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scroll_down_stops_at_max_scroll_and_scroll_up_recovers_immediately() {
+        let mut help = HelpState {
+            max_scroll: 3,
+            ..Default::default()
+        };
+
+        for _ in 0..10 {
+            help.scroll_down();
+        }
+        assert_eq!(help.scroll, 3);
+
+        help.scroll_up();
+        assert_eq!(help.scroll, 2);
+    }
+
+    #[test]
+    fn scroll_up_never_goes_below_zero() {
+        let mut help = HelpState {
+            max_scroll: 3,
+            ..Default::default()
+        };
+
+        help.scroll_up();
+        assert_eq!(help.scroll, 0);
+
+        help.scroll_down();
+        help.scroll_up();
+        help.scroll_up();
+        assert_eq!(help.scroll, 0);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -209,7 +209,11 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     }
 
     if app.state.help.open {
-        help::draw(f, app, area);
+        // Persist the rendered scroll limit so scroll_down clamps at the real
+        // bottom; clamping scroll here also heals drift after a resize.
+        let max_scroll = help::draw(f, app, area);
+        app.state.help.max_scroll = max_scroll;
+        app.state.help.scroll = app.state.help.scroll.min(max_scroll);
     }
 
     toast::draw_toast(f, app, colors);

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -44,7 +44,9 @@ const POPUP_WIDTH: u16 = 64;
 const POPUP_HEIGHT: u16 = 24;
 const KEY_COL_WIDTH: usize = 16;
 
-pub(super) fn draw(f: &mut Frame, app: &App, area: Rect) {
+/// Renders the popup and returns the scroll limit implied by the rendered
+/// geometry, for the caller to persist into [`crate::state::HelpState`].
+pub(super) fn draw(f: &mut Frame, app: &App, area: Rect) -> usize {
     let help = &app.state.help;
     let colors = app.current_theme();
 
@@ -81,7 +83,8 @@ pub(super) fn draw(f: &mut Frame, app: &App, area: Rect) {
     );
 
     let visible = (inner.height.saturating_sub(1)) as usize;
-    let scroll = help.scroll.min(HELP_ITEMS.len().saturating_sub(visible));
+    let max_scroll = HELP_ITEMS.len().saturating_sub(visible);
+    let scroll = help.scroll.min(max_scroll);
     for (i, (key, desc)) in HELP_ITEMS.iter().enumerate().skip(scroll).take(visible) {
         let line_area = Rect {
             y: inner.y + (i - scroll) as u16,
@@ -96,4 +99,5 @@ pub(super) fn draw(f: &mut Frame, app: &App, area: Rect) {
         };
         f.render_widget(Paragraph::new(line).style(style), line_area);
     }
+    max_scroll
 }


### PR DESCRIPTION
## 变更说明

修复 #70 中描述的帮助窗口滚动 bug。

**根因**：`HelpState::scroll_down` 对 `scroll` 无上限累加，渲染层（`ui/help.rs`）仅对显示值做了 `min` 钳制，状态本身仍会越过底部继续增长。于是到底后继续下滚 UI 看似锁定，但向上滚动时需要先抵消溢出的部分视图才会移动。

**修复**：
- `state/help.rs`：新增 `max_scroll` 字段，`scroll_down` 改为 `(scroll + 1).min(max_scroll)` 在源头钳制；
- `ui/help.rs`：`draw` 返回由实际渲染几何（弹窗内高随终端尺寸变化）推导出的滚动上限；
- `ui.rs`：渲染后将 `max_scroll` 写回 `HelpState`，并把现有 `scroll` 钳制到新上限，顺带修复终端缩小后残留的越界偏移。

设计说明：采用"渲染时计算并返回、调用处写回"而非让 `draw` 持有 `&mut App`，因为 `current_theme()` 返回的 `&Theme` 借用在绘制期间存活，中间无法可变借用整个 `App`；写回仅触碰 `app.state.help` 字段路径，借用检查可通过，也避免每帧克隆主题。

## 相关 Issue

Fixes #70

## 测试情况

- 新增 2 个单元测试：`scroll_down_stops_at_max_scroll_and_scroll_up_recovers_immediately`（到底后继续下滚不再累加、上滚立即生效）、`scroll_up_never_goes_below_zero`（上滚不为负）
- `cargo test` 全部通过（61 单元测试 + 8 集成测试）
- `cargo fmt` / `cargo clippy` 无新增警告

## 手动验证

按 ? 进入帮助界面，按 j 滚动到底后继续按 j 多次，再按 k / ↑ 立即正常上移，无需抵消溢出；鼠标滚轮同理。