### PR TITLE
feat: 增加完整的 MPRIS2 支持

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +186,102 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -305,6 +425,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -562,6 +695,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +822,12 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crossterm"
@@ -948,6 +1096,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1119,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -990,6 +1165,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1149,6 +1344,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1474,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -1907,6 +2121,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpris-server"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70cf358e9a9516cc35ed40eebd56cbe80f5190a7a2b3cd0c2d358c86b879132b"
+dependencies = [
+ "async-channel",
+ "futures-channel",
+ "serde",
+ "trait-variant",
+ "zbus",
+]
+
+[[package]]
 name = "ncm-api"
 version = "0.1.0"
 dependencies = [
@@ -2247,6 +2474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2528,12 @@ checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
 dependencies = [
  "libm",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2443,6 +2686,7 @@ dependencies = [
  "image",
  "libc",
  "log",
+ "mpris-server",
  "ncm-api",
  "qrcode",
  "rand 0.10.2",
@@ -2467,6 +2711,17 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs1"
@@ -2506,6 +2761,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3194,6 +3463,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3821,6 +4101,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -4001,6 +4282,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trait-variant"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b19a4867a870f6edc4c283f2b455804b1879c0baf0e642f26b03ed8ee262d9d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4017,6 +4309,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -4755,6 +5058,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4853,4 +5227,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ dirs = "6.0.0"
 futures = { version = "0.3.33", default-features = false, features = ["async-await", "std"] }
 image = { version = "0.25.10", default-features = false, features = ["jpeg"] }
 log = { version = "0.4.33", features = ["serde", "std"] }
+mpris-server = { version = "0.10.0", features = ["tokio"] }
 ncm-api = { path = "crates/ncm-api" }
 qrcode = "0.14.1"
 rand = "0.10.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -344,6 +344,11 @@ impl App {
                 }
             }
             IpcEvent::TogglePlay => self.playback.toggle_pause(),
+            IpcEvent::Stop => self.playback.stop_for_external_control(),
+            IpcEvent::SeekRelative { seconds } => self.playback.seek_relative(seconds),
+            IpcEvent::SeekAbsolute { seconds } => self.playback.seek_absolute(seconds),
+            IpcEvent::SetLoopStatus { status } => self.playback.set_loop_status_key(&status),
+            IpcEvent::SetShuffle { shuffle } => self.playback.set_shuffle(shuffle),
             IpcEvent::Volume { delta, absolute } => {
                 if let Some(delta) = delta {
                     self.adjust_volume(delta);
@@ -416,6 +421,11 @@ impl App {
             self.state.events.sender(),
             Arc::clone(&self.searcher),
         );
+        let _mpris_guard = crate::mpris::start(
+            Arc::clone(&self.status),
+            self.status_tx.clone(),
+            self.state.events.sender(),
+        );
         while self.state.running {
             self.update_status_snapshot();
             terminal.draw(|frame| self.draw(frame))?;
@@ -483,6 +493,11 @@ impl App {
             self.status_tx.clone(),
             self.state.events.sender(),
             Arc::clone(&self.searcher),
+        );
+        let _mpris_guard = crate::mpris::start(
+            Arc::clone(&self.status),
+            self.status_tx.clone(),
+            self.state.events.sender(),
         );
 
         // Resolve the user session from cookies so login-gated endpoints like

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -495,6 +495,7 @@ mod tests {
             paused: false,
             mode: "sequential".into(),
             liked: true,
+            ..StatusSnapshot::default()
         }
     }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -90,6 +90,19 @@ pub enum MsgAction {
     Like,
     Dislike,
     ToggleLike,
+    Stop,
+    SeekRelative {
+        seconds: f64,
+    },
+    SeekAbsolute {
+        seconds: f64,
+    },
+    SetLoopStatus {
+        status: String,
+    },
+    SetShuffle {
+        shuffle: bool,
+    },
     /// Dynamically switch the daemon's queue to another endpoint. `endpoint` is
     /// an API endpoint name (e.g. `toplist`, `liked`); `playlist` optionally
     /// picks the 1-based playlist within list-type endpoints.
@@ -117,6 +130,19 @@ pub enum IpcEvent {
     Like,
     Dislike,
     ToggleLike,
+    Stop,
+    SeekRelative {
+        seconds: f64,
+    },
+    SeekAbsolute {
+        seconds: f64,
+    },
+    SetLoopStatus {
+        status: String,
+    },
+    SetShuffle {
+        shuffle: bool,
+    },
     SwitchList {
         endpoint: String,
         playlist: Option<usize>,
@@ -136,6 +162,11 @@ impl From<MsgAction> for IpcEvent {
             MsgAction::Like => IpcEvent::Like,
             MsgAction::Dislike => IpcEvent::Dislike,
             MsgAction::ToggleLike => IpcEvent::ToggleLike,
+            MsgAction::Stop => IpcEvent::Stop,
+            MsgAction::SeekRelative { seconds } => IpcEvent::SeekRelative { seconds },
+            MsgAction::SeekAbsolute { seconds } => IpcEvent::SeekAbsolute { seconds },
+            MsgAction::SetLoopStatus { status } => IpcEvent::SetLoopStatus { status },
+            MsgAction::SetShuffle { shuffle } => IpcEvent::SetShuffle { shuffle },
             MsgAction::SwitchList { endpoint, playlist } => {
                 IpcEvent::SwitchList { endpoint, playlist }
             }
@@ -162,6 +193,8 @@ pub struct StatusSnapshot {
     /// `shuffle` / `heartbeat`.
     pub mode: String,
     pub liked: bool,
+    pub art_url: String,
+    pub lyrics: String,
 }
 
 impl StatusSnapshot {
@@ -183,6 +216,18 @@ impl StatusSnapshot {
             paused: state.paused,
             mode: mode_key(&state.mode).to_string(),
             liked: state.liked,
+            art_url: song.map(|s| s.pic_url.clone()).unwrap_or_default(),
+            lyrics: state
+                .lyrics
+                .as_ref()
+                .map(|lines| {
+                    lines
+                        .iter()
+                        .map(|line| line.text.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                })
+                .unwrap_or_default(),
         }
     }
 
@@ -201,6 +246,8 @@ impl StatusSnapshot {
             || self.paused != other.paused
             || self.mode != other.mode
             || self.liked != other.liked
+            || self.art_url != other.art_url
+            || self.lyrics != other.lyrics
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod input;
 pub mod ipc;
 pub mod layout;
 pub mod logger;
+pub mod mpris;
 pub mod playback;
 pub mod service;
 pub mod state;

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -1,0 +1,196 @@
+//! MPRIS2 integration for desktop media controls.
+
+use std::sync::{Arc, Mutex};
+
+use mpris_server::{LoopStatus, Metadata, PlaybackStatus, Player, Time, TrackId};
+use tokio::sync::{broadcast, mpsc};
+
+use crate::{
+    event::{AppEvent, Event},
+    ipc::{IpcEvent, StatusSnapshot},
+};
+
+/// Keep the MPRIS worker alive for as long as the application is running.
+pub struct MprisGuard {
+    _thread: std::thread::JoinHandle<()>,
+}
+
+/// Start the MPRIS service on a local Tokio runtime.
+///
+/// `mpris-server::Player` deliberately uses local state, so it is kept on its
+/// own current-thread runtime. DBus callbacks only enqueue normal app events;
+/// all playback mutation remains on the app event loop.
+pub fn start(
+    status: Arc<Mutex<StatusSnapshot>>,
+    status_tx: broadcast::Sender<StatusSnapshot>,
+    event_tx: mpsc::UnboundedSender<Event>,
+) -> MprisGuard {
+    let thread = std::thread::Builder::new()
+        .name("pigma-mpris".into())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    log::warn!("mpris: failed to create runtime: {error}");
+                    return;
+                }
+            };
+            runtime.block_on(run(status, status_tx, event_tx));
+        })
+        .expect("failed to start MPRIS thread");
+
+    MprisGuard { _thread: thread }
+}
+
+async fn run(
+    status: Arc<Mutex<StatusSnapshot>>,
+    status_tx: broadcast::Sender<StatusSnapshot>,
+    event_tx: mpsc::UnboundedSender<Event>,
+) {
+    let player = match Player::builder("pigma")
+        .identity("pigma")
+        .desktop_entry("pigma")
+        .can_go_next(true)
+        .can_go_previous(true)
+        .can_play(true)
+        .can_pause(true)
+        .can_seek(true)
+        .can_control(true)
+        .build()
+        .await
+    {
+        Ok(player) => player,
+        Err(error) => {
+            log::warn!("mpris: failed to claim DBus name: {error}");
+            return;
+        }
+    };
+
+    connect_callbacks(&player, &event_tx);
+    let mut updates = status_tx.subscribe();
+    let initial = status
+        .lock()
+        .map(|snapshot| snapshot.clone())
+        .unwrap_or_default();
+    apply_snapshot(&player, &initial).await;
+
+    let server_task = player.run();
+    tokio::pin!(server_task);
+    loop {
+        tokio::select! {
+            _ = &mut server_task => break,
+            update = updates.recv() => match update {
+                Ok(snapshot) => apply_snapshot(&player, &snapshot).await,
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    if let Ok(snapshot) = status.lock().map(|snapshot| snapshot.clone()) {
+                        apply_snapshot(&player, &snapshot).await;
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    }
+}
+
+fn connect_callbacks(player: &Player, event_tx: &mpsc::UnboundedSender<Event>) {
+    let tx = event_tx.clone();
+    player.connect_next(move |_| {
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::Next)));
+    });
+    let tx = event_tx.clone();
+    player.connect_previous(move |_| {
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::Previous)));
+    });
+    let tx = event_tx.clone();
+    player.connect_pause(move |_| {
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::Pause)));
+    });
+    let tx = event_tx.clone();
+    player.connect_play(move |_| {
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::Play { song_id: None })));
+    });
+    let tx = event_tx.clone();
+    player.connect_play_pause(move |_| {
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::TogglePlay)));
+    });
+    let tx = event_tx.clone();
+    player.connect_stop(move |_| {
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::Stop)));
+    });
+    let tx = event_tx.clone();
+    player.connect_seek(move |_, offset| {
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::SeekRelative {
+            seconds: offset.as_micros() as f64 / 1_000_000.0,
+        })));
+    });
+    let tx = event_tx.clone();
+    player.connect_set_position(move |_, _, position| {
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::SeekAbsolute {
+            seconds: position.as_micros().max(0) as f64 / 1_000_000.0,
+        })));
+    });
+    let tx = event_tx.clone();
+    player.connect_set_volume(move |_, volume| {
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::Volume {
+            delta: None,
+            absolute: Some(volume.clamp(0.0, 1.0)),
+        })));
+    });
+    let tx = event_tx.clone();
+    player.connect_set_loop_status(move |_, loop_status| {
+        let status = match loop_status {
+            LoopStatus::None => "none",
+            LoopStatus::Track => "track",
+            LoopStatus::Playlist => "playlist",
+        };
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::SetLoopStatus {
+            status: status.into(),
+        })));
+    });
+    let tx = event_tx.clone();
+    player.connect_set_shuffle(move |_, shuffle| {
+        let _ = tx.send(Event::App(AppEvent::Ipc(IpcEvent::SetShuffle { shuffle })));
+    });
+}
+
+async fn apply_snapshot(player: &Player, snapshot: &StatusSnapshot) {
+    let playback_status = if snapshot.playing && !snapshot.paused {
+        PlaybackStatus::Playing
+    } else if snapshot.paused {
+        PlaybackStatus::Paused
+    } else {
+        PlaybackStatus::Stopped
+    };
+    let _ = player.set_playback_status(playback_status).await;
+    let _ = player.set_volume(snapshot.volume.clamp(0.0, 1.0)).await;
+    player.set_position(Time::from_millis(snapshot.position_ms as i64));
+
+    let loop_status = match snapshot.mode.as_str() {
+        "repeat_one" => LoopStatus::Track,
+        "repeat_all" => LoopStatus::Playlist,
+        _ => LoopStatus::None,
+    };
+    let _ = player.set_loop_status(loop_status).await;
+    let _ = player.set_shuffle(snapshot.mode == "shuffle").await;
+
+    let mut metadata = Metadata::builder()
+        .trackid(track_id(snapshot.id))
+        .title(snapshot.name.clone())
+        .artist([snapshot.artist.clone()])
+        .album(snapshot.album.clone())
+        .length(Time::from_millis(snapshot.duration_ms as i64));
+    if !snapshot.art_url.is_empty() {
+        metadata = metadata.art_url(snapshot.art_url.clone());
+    }
+    if !snapshot.lyrics.is_empty() {
+        metadata = metadata.lyrics(snapshot.lyrics.clone());
+    }
+    let _ = player.set_metadata(metadata.build()).await;
+}
+
+fn track_id(id: u64) -> TrackId {
+    TrackId::try_from(format!("/org/pigma/track/{id}")).unwrap_or(TrackId::NO_TRACK)
+}

--- a/src/playback/engine.rs
+++ b/src/playback/engine.rs
@@ -570,6 +570,10 @@ impl PlaybackEngine {
         self.state.seeking = false;
     }
 
+    pub fn stop_for_external_control(&mut self) {
+        self.stop();
+    }
+
     pub fn clear_queue(&mut self) {
         // Only stop the current playback when the cleared queue is the one the
         // playing song came from. Clearing a different queue (viewed on the
@@ -630,6 +634,17 @@ impl PlaybackEngine {
         self.controller.seek_to(Duration::from_secs_f64(new_secs));
     }
 
+    pub fn seek_absolute(&mut self, seconds: f64) {
+        let current = self.state.progress
+            * self
+                .state
+                .current_song
+                .as_ref()
+                .map(|song| song.duration as f64 / 1000.0)
+                .unwrap_or(0.0);
+        self.seek_relative(seconds - current);
+    }
+
     pub fn set_volume(&mut self, volume: f64) {
         self.state.volume = volume;
         self.controller.set_volume(volume as f32);
@@ -652,6 +667,23 @@ impl PlaybackEngine {
         };
         self.set_mode(next);
         next
+    }
+
+    pub fn set_loop_status_key(&mut self, status: &str) {
+        let mode = match status {
+            "track" => PlayMode::RepeatOne,
+            "playlist" => PlayMode::RepeatAll,
+            _ => PlayMode::Sequential,
+        };
+        self.set_mode(mode);
+    }
+
+    pub fn set_shuffle(&mut self, shuffle: bool) {
+        if shuffle {
+            self.set_mode(PlayMode::Shuffle);
+        } else if matches!(self.state.mode, PlayMode::Shuffle) {
+            self.set_mode(PlayMode::Sequential);
+        }
     }
 
     pub(super) fn set_mode(&mut self, mode: PlayMode) {

--- a/tests/ipc.rs
+++ b/tests/ipc.rs
@@ -68,6 +68,7 @@ async fn status_round_trip() {
         position_ms: 25_000,
         volume: 0.5,
         playing: true,
+        liked: true,
         ..Default::default()
     };
     let snapshot = Arc::new(Mutex::new(snapshot));
@@ -286,6 +287,7 @@ async fn subscribe_streams_updates() {
         artist: "Artist B".into(),
         playing: true,
         paused: true,
+        liked: true,
         ..Default::default()
     };
     status_tx.send(snapshot.lock().unwrap().clone()).unwrap();


### PR DESCRIPTION
## 概述

为 pigma 增加完整的 MPRIS2 支持，使其可以被
GNOME、KDE、playerctl 、DankMaterialShell等Linux桌面媒体控制组件识别和管理。

## 新增功能

- 注册 MPRIS 服务名 `org.mpris.MediaPlayer2.pigma`
- 推送歌曲元数据：
  - 歌曲标题
  - 歌手
  - 专辑
  - 播放时长
  - 封面 URL
  - 纯文本歌词
- 支持远程播放控制：
  - 播放
  - 暂停
  - 播放/暂停切换
  - 停止
  - 上一曲
  - 下一曲
  - 相对快进/快退
  - 绝对进度定位
  - 音量控制
- 支持播放模式切换：
  - 不循环
  - 单曲循环
  - 列表循环
  - 随机播放
- 实时同步播放状态、播放进度、音量、歌曲元数据和播放模式
- TUI 模式和无头 daemon 模式均支持 MPRIS
<img width="2852" height="1768" alt="2026-09-08_14-05-46" src="https://github.com/user-attachments/assets/3cc4ae76-a0e4-4e60-b965-778f0264e8db" />


## 实现方式

- 使用 `mpris-server` 集成 MPRIS2 和 D-Bus。
- MPRIS 回调通过现有事件通道发送到主应用事件循环。
- 扩展 `StatusSnapshot`，加入封面 URL 和歌词字段。
- 复用现有播放器引擎实现播放、定位和播放模式控制。
- DBus 工作线程不直接修改播放器状态，避免线程安全问题。
<img width="2852" height="1768" alt="2026-09-08_14-05-46" src="https://github.com/user-attachments/assets/4a7f59de-875f-41f0-a8ff-863e3afcab2a" />
